### PR TITLE
fix(test): remove hardcoded version assertion

### DIFF
--- a/tests/integration/test_library_api.py
+++ b/tests/integration/test_library_api.py
@@ -48,7 +48,9 @@ class TestPublicApiExports:
 
     def test_version_exported(self) -> None:
         assert hasattr(aws_pick, "__version__")
-        assert aws_pick.__version__ == "0.1.0"
+        assert isinstance(aws_pick.__version__, str)
+        parts = aws_pick.__version__.split(".")
+        assert len(parts) >= 2
 
     def test_all_list(self) -> None:
         expected = {


### PR DESCRIPTION
## Summary
- Replace hardcoded `== "0.1.0"` version check with format validation so version bumps don't break CI

Addresses #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)