### PR TITLE
feat(tui): visual overhaul for polished design

### DIFF
--- a/src/aws_pick/tui/screens/selector.py
+++ b/src/aws_pick/tui/screens/selector.py
@@ -63,14 +63,7 @@ class SelectorScreen(Screen[list[AccountRole] | None]):
 
     def compose(self) -> ComposeResult:
         with Vertical(id="panel"):
-            yield Static(self._title, id="panel-title")
-            yield Static(
-                "[bold cyan]Space[/] [dim]toggle[/]  [dim]·[/]  "
-                "[bold cyan]Enter[/] [dim]confirm[/]  [dim]·[/]  "
-                "[bold cyan]Tab[/] [dim]filter[/]  [dim]·[/]  "
-                "[bold cyan]?[/] [dim]help[/]",
-                id="panel-hint",
-            )
+            yield Static(f"[bold cyan]{self._title}[/]", id="panel-title")
             yield FilterBar()
             yield AccountList(
                 self._items,

--- a/src/aws_pick/tui/styles/app.tcss
+++ b/src/aws_pick/tui/styles/app.tcss
@@ -4,13 +4,12 @@ SelectorScreen {
     align: center middle;
 }
 
-/* Centered panel - auto-sizes vertically to content */
 #panel {
-    width: 56;
+    width: 60;
     height: auto;
     max-height: 90%;
     background: $surface;
-    border: tall $primary;
+    border: round $accent;
     padding: 1 2;
 }
 
@@ -18,13 +17,7 @@ SelectorScreen {
     text-align: center;
     text-style: bold;
     width: 100%;
-    color: $accent;
-}
-
-#panel-hint {
-    text-align: center;
-    color: $text-muted;
-    width: 100%;
+    color: $text;
     margin-bottom: 1;
 }
 
@@ -50,6 +43,7 @@ AccountList {
 StatusBar {
     dock: bottom;
     height: 1;
-    color: $text-muted;
+    background: $surface-darken-1;
     text-align: center;
+    margin-top: 1;
 }

--- a/src/aws_pick/tui/widgets/account_list.py
+++ b/src/aws_pick/tui/widgets/account_list.py
@@ -138,7 +138,9 @@ class AccountList(Widget):
 
     def _render_favorites_section(self, option_list: OptionList, fav_items: list[AccountRole]) -> None:
         """Render the favorites group at the top."""
-        header_text = Text("  ★ Favorites", style="bold yellow")
+        header_text = Text("  ")
+        header_text.append("★", style="bold yellow")
+        header_text.append(" Favorites", style="bold")
         option_list.add_option(Option(header_text, id="header:favorites", disabled=True))
         for ar in sorted(fav_items, key=lambda r: f"{r.account.account_name}/{r.role.role_name}"):
             self._add_item_option(
@@ -159,9 +161,10 @@ class AccountList(Widget):
             first_group = False
 
             env_info = classify(roles[0].account)
-            header_text = Text(f"  {account_name}", style="bold")
+            header_text = Text("  ")
+            header_text.append(account_name, style="bold")
             if env_info:
-                header_text.append(f" [{env_info.environment}]", style=_env_style(env_info.environment))
+                header_text.append(f"  {env_info.environment}", style=_env_style(env_info.environment))
             option_list.add_option(Option(header_text, id=f"header:{account_name}", disabled=True))
 
             for ar in sorted(roles, key=lambda r: r.role.role_name):
@@ -180,7 +183,8 @@ class AccountList(Widget):
                 option_list.add_option(Option(Text(""), disabled=True))
             first_group = False
 
-            header_text = Text(f"  {role_name}", style="bold")
+            header_text = Text("  ")
+            header_text.append(role_name, style="bold")
             option_list.add_option(Option(header_text, id=f"header:{role_name}", disabled=True))
 
             for ar in sorted(role_items, key=lambda r: r.account.account_name):

--- a/src/aws_pick/tui/widgets/status_bar.py
+++ b/src/aws_pick/tui/widgets/status_bar.py
@@ -1,4 +1,4 @@
-"""Footer status bar showing selection count, grouping mode, and keyboard hints."""
+"""Footer status bar showing selection count and keyboard hints."""
 
 from __future__ import annotations
 
@@ -8,7 +8,7 @@ from textual.widget import Widget
 
 
 class StatusBar(Widget):
-    """Displays selection count, grouping mode, and key hints at the bottom of the screen."""
+    """Displays selection count and key hints at the bottom of the panel."""
 
     selected_count: reactive[int] = reactive(0)
     grouping_label: reactive[str] = reactive("account")
@@ -16,6 +16,17 @@ class StatusBar(Widget):
     def render(self) -> Text:
         count = self.selected_count
         line = Text()
-        line.append(f"{count} selected", style="bold")
-        line.append("  ·  g: cycle grouping", style="dim")
+        line.append(f" {count} ", style="bold reverse cyan")
+        line.append(" selected", style="bold")
+        line.append("    ", style="dim")
+        for key, action, last in [
+            ("Space", "toggle", False),
+            ("Enter", "confirm", False),
+            ("Tab", "filter", False),
+            ("?", "help", True),
+        ]:
+            line.append(key, style="bold cyan")
+            line.append(f" {action}", style="dim")
+            if not last:
+                line.append("  ", style="dim")
         return line


### PR DESCRIPTION
## Summary
- Redesigned status bar with reverse-video cyan count badge and inline key hints
- Simplified header to bold cyan title only (removed hint text)
- Changed panel border to round accent style, widened to 60 chars
- Cleaned up group headers (env tags without brackets)
- Added dark background tint to status bar

Closes #8

## Test plan
- [x] All 225 tests pass
- [x] Ruff clean
- [ ] Visual check via `python demo.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)