### PR TITLE
chore: release v0.1.2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,7 @@ name: Publish to PyPI
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   test:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "aws-pick"
-version = "0.1.1"
+version = "0.1.2"
 description = "CLI and TUI tool for selecting AWS account/role credentials"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/aws_pick/__init__.py
+++ b/src/aws_pick/__init__.py
@@ -1,6 +1,6 @@
 """aws-pick - Interactive TUI and Python library for selecting AWS account/role credentials."""
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 
 from aws_pick.core.favorites import manage_favorites
 from aws_pick.core.presets import manage_presets


### PR DESCRIPTION
## Summary
- Bump version to 0.1.2
- Add workflow_dispatch trigger to publish workflow for manual releases

Closes #10

## Test plan
- [ ] Verify version is 0.1.2 in pyproject.toml and __init__.py
- [ ] After merge, create release v0.1.2 to trigger PyPI publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)